### PR TITLE
Add support for viewing bundle logs for action.

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -81,6 +81,7 @@ var bundleInfoCmd = &cobra.Command{
 var bundleNamespace string
 var sandboxRole string
 var kubeConfig string
+var printLogs bool
 
 var bundleProvisionCmd = &cobra.Command{
 	Use:   "provision <bundle name>",
@@ -120,11 +121,13 @@ func init() {
 	bundleProvisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision bundle to")
 	bundleProvisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
 	bundleProvisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
+	bundleProvisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from provision pod")
 	bundleCmd.AddCommand(bundleProvisionCmd)
 
-	bundleDeprovisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision bundle to")
+	bundleDeprovisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to deprovision bundle from")
 	bundleDeprovisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
 	bundleDeprovisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
+	bundleDeprovisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from deprovision pod")
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
 }
 
@@ -173,7 +176,7 @@ func executeBundle(action string, args []string) {
 		}
 	}
 	log.Debugf("Running bundle [%v] with action [%v] in namespace [%v].", args[0], action, bundleNamespace)
-	runner.RunBundle(action, bundleNamespace, args[0], sandboxRole, bundleRegistry, args[1:])
+	runner.RunBundle(action, bundleNamespace, args[0], sandboxRole, bundleRegistry, printLogs, args[1:])
 }
 
 // Get images from a single registry

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,12 +17,15 @@
 package runner
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/clients"
@@ -38,7 +41,7 @@ import (
 )
 
 // RunBundle will run the bundle's action in the given namespace
-func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, args []string) {
+func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, args []string) {
 	reg := []Registry{}
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
@@ -154,8 +157,44 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 		return
 	}
 	fmt.Printf("Successfully created pod [%v] to %s [%v] in namespace [%v]\n", pn, ec.Action, bundleName, ns)
+
+	if printLogs {
+		printBundleLogs(pn, ns, action)
+	}
+
 	// TODO: return nil
 	return
+}
+
+func printBundleLogs(podName string, namespace string, action string) {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	logTailRequest := k8scli.Client.CoreV1().Pods(namespace).GetLogs(podName, &v1.PodLogOptions{Follow: true})
+
+	var requestStream io.ReadCloser
+	var podStarted bool
+
+	for podStarted == false {
+		requestStream, err = logTailRequest.Stream()
+		if err != nil {
+			fmt.Printf("Waiting for bundle [%v] pod [%v] to start...\n", action, podName)
+			log.Debugf("%v", err)
+			time.Sleep(3 * time.Second)
+		} else {
+			fmt.Printf("Pod started. Reading logs...\n")
+			podStarted = true
+		}
+	}
+	defer requestStream.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(requestStream)
+	fmt.Println("-+- --------------------- -+-")
+	fmt.Println(" |       BUNDLE LOGS       | ")
+	fmt.Println("-+- --------------------- -+-")
+	fmt.Println(buf.String())
 }
 
 func selectPlan(spec *bundle.Spec) bundle.Plan {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,7 +17,6 @@
 package runner
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -189,12 +188,20 @@ func printBundleLogs(podName string, namespace string, action string) {
 		}
 	}
 	defer requestStream.Close()
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(requestStream)
+
 	fmt.Println("-+- --------------------- -+-")
 	fmt.Println(" |       BUNDLE LOGS       | ")
 	fmt.Println("-+- --------------------- -+-")
-	fmt.Println(buf.String())
+
+	buf := make([]byte, 100)
+	var doneReading bool
+	for doneReading == false {
+		n, err := requestStream.Read(buf)
+		if err == io.EOF {
+			doneReading = true
+		}
+		fmt.Printf("%s", buf[:n])
+	}
 }
 
 func selectPlan(spec *bundle.Spec) bundle.Plan {


### PR DESCRIPTION
Added `-f` and `--follow` options to provision and deprovision so that you can automatically view the logs that result from the bundle run.

Addresses https://github.com/automationbroker/apb/issues/46

```
[dwhatley@precision-t apb]$ apb bundle provision mediawiki-apb -n foobar --follow
Found bundle [mediawiki-apb] in registry [docker]
Plan: default
Enter value for parameter [mediawiki_db_schema], default: [mediawiki]: 
[...]
INFO Creating RoleBinding bundle-867f2119-bf84-47d5-86ec-776163c21704 
INFO Successfully created apb sandbox: [ bundle-867f2119-bf84-47d5-86ec-776163c21704 ], with edit permissions in namespace foobar 
INFO Running post create sandbox functions if defined. 
Successfully created pod [bundle-867f2119-bf84-47d5-86ec-776163c21704] to provision [mediawiki-apb] in namespace [foobar]
Waiting for bundle [provision] pod [bundle-867f2119-bf84-47d5-86ec-776163c21704] to start...
Waiting for bundle [provision] pod [bundle-867f2119-bf84-47d5-86ec-776163c21704] to start...
Pod started. Reading logs...
-+- --------------------- -+-
 |       BUNDLE LOGS       | 
-+- --------------------- -+-
[...]
PLAY [mediawiki-apb provision] *************************************************
[...]
PLAY RECAP *********************************************************************
localhost                  : ok=6    changed=1    unreachable=0    failed=0   
```

