### PR TITLE
Match old apb commands

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -69,7 +69,10 @@ func init() {
 	rootCmd.AddCommand(brokerCmd)
 
 	brokerCmd.AddCommand(brokerCatalogCmd)
+	rootCmd.AddCommand(createHiddenCmd(brokerCatalogCmd, "running 'apb broker catalog'"))
+
 	brokerCmd.AddCommand(brokerBootstrapCmd)
+	rootCmd.AddCommand(createHiddenCmd(brokerBootstrapCmd, "running 'apb broker boostrap'"))
 }
 
 func listBrokerCatalog() {

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -110,24 +110,29 @@ func init() {
 	bundlePrepareCmd.Flags().StringVarP(&bundleMetadataFilename, "bundlemeta", "b", "apb.yml", "Bundle metadata file to encode as b64")
 	bundlePrepareCmd.Flags().StringVarP(&containerMetadataFilename, "containermeta", "c", "Dockerfile", "Container metadata file to stamp")
 	bundlePrepareCmd.Flags().BoolVarP(&noLineBreaks, "nolinebreak", "n", false, "Skip adding linebreaks to b64 bundle spec")
+	rootCmd.AddCommand(createHiddenCmd(bundlePrepareCmd, "running 'apb bundle prepare'"))
 	bundleCmd.AddCommand(bundlePrepareCmd)
 
 	bundleListCmd.Flags().BoolVarP(&Refresh, "refresh", "r", false, "refresh list of specs")
+	rootCmd.AddCommand(createHiddenCmd(bundleListCmd, "running 'apb bundle list'"))
 	bundleCmd.AddCommand(bundleListCmd)
 
 	bundleInfoCmd.Flags().StringVarP(&bundleRegistry, "registry", "r", "", "Registry to retrieve bundle info from")
+	rootCmd.AddCommand(createHiddenCmd(bundleInfoCmd, "running 'apb bundle info'"))
 	bundleCmd.AddCommand(bundleInfoCmd)
 
 	bundleProvisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision bundle to")
 	bundleProvisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
 	bundleProvisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
 	bundleProvisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from provision pod")
+	rootCmd.AddCommand(createHiddenCmd(bundleProvisionCmd, ""))
 	bundleCmd.AddCommand(bundleProvisionCmd)
 
 	bundleDeprovisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to deprovision bundle from")
 	bundleDeprovisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
 	bundleDeprovisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
 	bundleDeprovisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from deprovision pod")
+	rootCmd.AddCommand(createHiddenCmd(bundleDeprovisionCmd, ""))
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
 }
 

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -139,7 +139,7 @@ func init() {
 	bundleCmd.AddCommand(bundlePrepareCmd)
 
 	bundleListCmd.Flags().BoolVarP(&Refresh, "refresh", "r", false, "refresh list of specs")
-	rootCmd.AddCommand(createHiddenCmd(bundleListCmd, "running 'apb bundle list'"))
+	rootCmd.AddCommand(createHiddenCmd(bundleListCmd, "running 'apb bundle list'. To list service bundles known to a broker, run 'apb broker catalog'"))
 	bundleCmd.AddCommand(bundleListCmd)
 
 	bundleInfoCmd.Flags().StringVarP(&bundleRegistry, "registry", "r", "", "Registry to retrieve bundle info from")

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -105,7 +105,7 @@ var bundleDeprovisionCmd = &cobra.Command{
 
 var bundleInitStub = &cobra.Command{
 	Use:        "init <bundle name>",
-	Deprecated: "must use 'ansible-galaxy init --type=apb <bundle name>'",
+	Deprecated: "use 'ansible-galaxy init --type=apb <bundle name>'",
 	Hidden:     true,
 }
 
@@ -160,8 +160,8 @@ func init() {
 	rootCmd.AddCommand(createHiddenCmd(bundleDeprovisionCmd, ""))
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
 
-	rootCmd.AddCommand(bundlePushStub)
-	bundleCmd.AddCommand(bundlePushStub)
+	rootCmd.AddCommand(bundleInitStub)
+	bundleCmd.AddCommand(bundleInitStub)
 
 	rootCmd.AddCommand(bundlePushStub)
 	bundleCmd.AddCommand(bundlePushStub)

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -69,7 +69,7 @@ var bundleListCmd = &cobra.Command{
 var bundleRegistry string
 
 var bundleInfoCmd = &cobra.Command{
-	Use:   "info <bundle name>",
+	Use:   "info <bundle-name>",
 	Short: "Print info on ServiceBundle image",
 	Long:  `Print metadata, plans, and params associated with ServiceBundle image`,
 	Args:  cobra.MinimumNArgs(1),
@@ -84,7 +84,7 @@ var kubeConfig string
 var printLogs bool
 
 var bundleProvisionCmd = &cobra.Command{
-	Use:   "provision <bundle name>",
+	Use:   "provision <bundle-name>",
 	Short: "Provision ServiceBundle images",
 	Long:  `Provision ServiceBundles from a registry adapter`,
 	Args:  cobra.MinimumNArgs(1),
@@ -94,7 +94,7 @@ var bundleProvisionCmd = &cobra.Command{
 }
 
 var bundleDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <bundle name>",
+	Use:   "deprovision <bundle-name>",
 	Short: "Deprovision ServiceBundle images",
 	Long:  `Deprovision ServiceBundles from a registry adapter`,
 	Args:  cobra.MinimumNArgs(1),
@@ -104,8 +104,8 @@ var bundleDeprovisionCmd = &cobra.Command{
 }
 
 var bundleInitStub = &cobra.Command{
-	Use:        "init <bundle name>",
-	Deprecated: "use 'ansible-galaxy init --type=apb <bundle name>'",
+	Use:        "init <bundle-name>",
+	Deprecated: "use 'ansible-galaxy init --type=apb <bundle-name>'",
 	Hidden:     true,
 }
 
@@ -113,7 +113,7 @@ const buildConfigCmd string = `oc new-build . --to <bundle-name>`
 const buildTriggerCmd string = `oc start-build --from-dir . <bundle-name>`
 
 var bundlePushStub = &cobra.Command{
-	Use: "push <bundle name>",
+	Use: "push <bundle-name>",
 	Deprecated: fmt.Sprintf("the OpenShift build system can be used instead.\n\n"+
 		"Create buildconfig: '%s'\n"+
 		"Start build:        '%s'\n", buildConfigCmd, buildTriggerCmd),

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -103,6 +103,31 @@ var bundleDeprovisionCmd = &cobra.Command{
 	},
 }
 
+var bundleInitStub = &cobra.Command{
+	Use:        "init <bundle name>",
+	Deprecated: "must use 'ansible-galaxy init --type=apb <bundle name>'",
+	Hidden:     true,
+}
+
+const buildConfigCmd string = `oc new-build . --to <bundle-name>`
+const buildTriggerCmd string = `oc start-build --from-dir . <bundle-name>`
+
+var bundlePushStub = &cobra.Command{
+	Use: "push <bundle name>",
+	Deprecated: fmt.Sprintf("the OpenShift build system can be used instead.\n\n"+
+		"Create buildconfig: '%s'\n"+
+		"Start build:        '%s'\n", buildConfigCmd, buildTriggerCmd),
+	Hidden: true,
+}
+
+var bundleBuildStub = &cobra.Command{
+	Use: "build",
+	Deprecated: fmt.Sprintf("the OpenShift build system can be used instead.\n\n"+
+		"Create buildconfig: '%s'\n"+
+		"Start build:        '%s'\n", buildConfigCmd, buildTriggerCmd),
+	Hidden: true,
+}
+
 func init() {
 	bundleCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "Path to kubeconfig to use")
 	rootCmd.AddCommand(bundleCmd)
@@ -134,6 +159,15 @@ func init() {
 	bundleDeprovisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from deprovision pod")
 	rootCmd.AddCommand(createHiddenCmd(bundleDeprovisionCmd, ""))
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
+
+	rootCmd.AddCommand(bundlePushStub)
+	bundleCmd.AddCommand(bundlePushStub)
+
+	rootCmd.AddCommand(bundlePushStub)
+	bundleCmd.AddCommand(bundlePushStub)
+
+	rootCmd.AddCommand(bundleBuildStub)
+	bundleCmd.AddCommand(bundleBuildStub)
 }
 
 // ListImages finds and prints inforomation on bundle images from all the registries
@@ -321,11 +355,7 @@ func stampBundleMetadata(bundleMetaFilename string, containerMetaFilename string
 		return
 	}
 	fmt.Printf("Wrote b64 encoded [%s] to [%s]\n\n", bundleMetaFilename, containerMetaFilename)
-
-	buildConfigCmd := `oc new-build . --to <bundle-name>`
 	fmt.Printf("Create a buildconfig:\n%s\n\n", buildConfigCmd)
-
-	buildTriggerCmd := `oc start-build --from-dir . <bundle-name>`
 	fmt.Printf("Start a build:\n%s\n\n", buildTriggerCmd)
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Creates a hidden copy of a cobra.Command with optional deprecation text
+func createHiddenCmd(cmd *cobra.Command, deprecatedText string) *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:        cmd.Use,
+		Short:      cmd.Short,
+		Long:       cmd.Long,
+		Args:       cmd.Args,
+		Run:        cmd.Run,
+		Hidden:     true,
+		Deprecated: deprecatedText,
+	}
+	newCmd.Flags().AddFlagSet(cmd.Flags())
+	return newCmd
+}


### PR DESCRIPTION
 - Provide top-level commands like in old APB tool
 - Hide top-level commands so that help-text is clean 
 - Add stubs for `apb init`, `apb build`, `apb push` with deprecation messages

Now you have the *option* of typing out the `bundle` in `apb bundle provision` which I think is great ;)