### PR TITLE
Add support for `apb catalog relist`

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -80,6 +80,14 @@ func listBrokerCatalog() {
 		return
 	}
 
+	// Check for user with valid bearer token
+	if kube.ClientConfig.BearerToken == "" {
+		fmt.Println("`apb broker catalog` requires a logged in user with a valid bearer token.")
+		fmt.Println("Users without a token include `system:admin`. Log in as a different user to continue.")
+		log.Error("Error: User did not have valid bearer token.")
+		return
+	}
+
 	brokerRoute, err := getBrokerRoute(brokerName)
 	if err != nil {
 		log.Errorf("Failed to get broker route: %v", err)
@@ -117,6 +125,14 @@ func bootstrapBroker() {
 	kube, err := clients.Kubernetes()
 	if err != nil {
 		log.Errorf("Failed to connect to cluster: %v", err)
+		return
+	}
+
+	// Check for user with valid bearer token
+	if kube.ClientConfig.BearerToken == "" {
+		fmt.Println("`apb broker bootstrap` requires a logged in user with a valid bearer token.")
+		fmt.Println("Users without a token include `system:admin`. Log in as a different user to continue.")
+		log.Error("Error: User did not have valid bearer token.")
 		return
 	}
 

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/automationbroker/apb/pkg/util"
 	"github.com/automationbroker/bundle-lib/clients"
@@ -82,15 +83,21 @@ func listBrokerCatalog() {
 
 	// Check for user with valid bearer token
 	if kube.ClientConfig.BearerToken == "" {
-		fmt.Println("`apb broker catalog` requires a logged in user with a valid bearer token.")
-		fmt.Println("Users without a token include `system:admin`. Log in as a different user to continue.")
-		log.Error("Error: User did not have valid bearer token.")
+		log.Error("Bearer token not found for current 'oc' user. Log in as a different user and retry.")
+		log.Info("View current token with 'oc whoami -t'")
+		log.Info("Some users don't have a token, including 'system:admin'")
 		return
 	}
 
 	brokerRoute, err := getBrokerRoute(brokerName)
 	if err != nil {
 		log.Errorf("Failed to get broker route: %v", err)
+		if strings.Contains(err.Error(), "cannot list routes") {
+			log.Errorf("Current 'oc' user unable to get 'routes' in namespace [%s]. Try again with a more privileged user.\n", brokerName)
+			log.Infof("Administrators can grant 'cluster-admin' privileges with:")
+			log.Infof("'oc adm policy add-cluster-role-to-user cluster-admin <oc-user>'")
+		}
+		return
 	}
 
 	osbConf := &osb.ClientConfiguration{
@@ -140,6 +147,11 @@ func bootstrapBroker() {
 	brokerRoute, err := getBrokerRoute(brokerName)
 	if err != nil {
 		log.Errorf("Failed to get broker route: %v", err)
+		if strings.Contains(err.Error(), "cannot list routes") {
+			log.Errorf("Current 'oc' user unable to get 'routes' in namespace [%s]. Try again with a more privileged user.\n", brokerName)
+			log.Infof("Administrators can grant 'cluster-admin' privileges with:")
+			log.Infof("'oc adm policy add-cluster-role-to-user cluster-admin <oc-user>'")
+		}
 		return
 	}
 

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -69,6 +69,13 @@ func relistCatalog() {
 		log.Errorf("Failed to connect to cluster: %v", err)
 		return
 	}
+	// Check for user with valid bearer token
+	if kube.ClientConfig.BearerToken == "" {
+		fmt.Println("`apb catalog relist` requires a logged in user with a valid bearer token.")
+		fmt.Println("This includes `system:admin`. Log in as a different user to continue.")
+		log.Error("Error: User did not have valid bearer token.")
+		return
+	}
 	// Get Cluster URL and form clusterservicebroker request
 	host := kube.ClientConfig.Host
 	brokerUrl := fmt.Sprintf(brokerResourceUrl, host, brokerResourceName)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -38,6 +38,7 @@ type relistResponse struct {
 }
 
 var brokerResourceName string
+var brokerResourceUrl = "%v/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/%v"
 
 var catalogCmd = &cobra.Command{
 	Use:   "catalog",
@@ -70,7 +71,7 @@ func relistCatalog() {
 	}
 	// Get Cluster URL and form clusterservicebroker request
 	host := kube.ClientConfig.Host
-	brokerUrl := fmt.Sprintf("%v/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/%v", host, brokerResourceName)
+	brokerUrl := fmt.Sprintf(brokerResourceUrl, host, brokerResourceName)
 
 	req, err := http.NewRequest("GET", brokerUrl, nil)
 	if err != nil {

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -72,7 +72,7 @@ func relistCatalog() {
 	// Check for user with valid bearer token
 	if kube.ClientConfig.BearerToken == "" {
 		fmt.Println("`apb catalog relist` requires a logged in user with a valid bearer token.")
-		fmt.Println("This includes `system:admin`. Log in as a different user to continue.")
+		fmt.Println("Users without a token include `system:admin`. Log in as a different user to continue.")
 		log.Error("Error: User did not have valid bearer token.")
 		return
 	}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	//"encoding/json"
+	"crypto/tls"
+	"fmt"
+	"github.com/automationbroker/bundle-lib/clients"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"net/http"
+)
+
+var catalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "Interact with OpenShift Service Catalog",
+	Long:  `Force the OpenShift Service Catalog to relist its group of APB specs`,
+}
+
+var catalogRelistCmd = &cobra.Command{
+	Use:   "relist",
+	Short: "relist service catalog",
+	Long:  `Force a relist of the OpenShift Service Catalog`,
+	Run: func(cmd *cobra.Command, args []string) {
+		relistCatalog()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(catalogCmd)
+	// Catalog Relist Flags
+	catalogCmd.AddCommand(catalogRelistCmd)
+}
+
+func relistCatalog() {
+	log.Debug("relistCatalog called")
+	kube, err := clients.Kubernetes()
+	if err != nil {
+		log.Errorf("Failed to connect to cluster: %v", err)
+		return
+	}
+	host := kube.ClientConfig.Host
+	brokerUrl := fmt.Sprintf("%v/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/%v", host, "ansible-service-broker")
+	req, err := http.NewRequest("GET", brokerUrl, nil)
+	if err != nil {
+		log.Errorf("Failed to create relist request: %v", err)
+		return
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", kube.ClientConfig.BearerToken))
+	cfg := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	http.DefaultClient.Transport = &http.Transport{
+		TLSClientConfig: cfg,
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Errorf("Failed to get relist response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		log.Errorf("Failed to get relist response. Expected status 200, got: %v", resp.StatusCode)
+		return
+	}
+	fmt.Printf("%#v\n", resp.Body)
+	return
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,11 +33,11 @@ var CfgFile string
 
 var rootCmd = &cobra.Command{
 	Use:   "apb",
-	Short: "apb is a tool to manage ServiceBundle images",
-	Long: `ServiceBundles are images that represent lifecycle components
-in that they contain all of the orchestration logic to manage
+	Short: "apb is a tool to manage Ansible Playbook Bundle images",
+	Long: `Ansible Playbook Bundles are images that represent lifecycle
+components in that they contain all of the orchestration logic to manage
 an application through out it's lifecycle, i.e. install, uninstall,
-bind, unbind, etc.  ServiceBundles are intended to be invoked and run
+bind, unbind, etc.  APBs are intended to be invoked and run
 as a short job to execute the intended work, example I want to deploy a
 postgres database to my kubernetes cluster.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -21,19 +21,3 @@ func GetCurrentNamespace(configPath string) string {
 	}
 	return strings.Split(config.CurrentContext, "/")[0]
 }
-
-func GetCurrentCluster(configPath string) string {
-	if configPath == "" {
-		configPath = clientcmd.RecommendedHomeFile
-	}
-	config, err := clientcmd.LoadFromFile(configPath)
-	if err != nil {
-		log.Errorf("Error loading kubeconfig from [%v]: %v", configPath, err)
-		return ""
-	}
-	if len(strings.Split(config.CurrentContext, "/")) < 3 {
-		log.Errorf("Did not find expected current-context string in kubeconfig.")
-		return ""
-	}
-	return strings.Split(config.CurrentContext, "/")[1]
-}

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -15,5 +15,25 @@ func GetCurrentNamespace(configPath string) string {
 		log.Errorf("Error loading kubeconfig from [%v]: %v", configPath, err)
 		return ""
 	}
+	if len(strings.Split(config.CurrentContext, "/")) < 3 {
+		log.Errorf("Did not find expected current-context string in kubeconfig.")
+		return ""
+	}
 	return strings.Split(config.CurrentContext, "/")[0]
+}
+
+func GetCurrentCluster(configPath string) string {
+	if configPath == "" {
+		configPath = clientcmd.RecommendedHomeFile
+	}
+	config, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		log.Errorf("Error loading kubeconfig from [%v]: %v", configPath, err)
+		return ""
+	}
+	if len(strings.Split(config.CurrentContext, "/")) < 3 {
+		log.Errorf("Did not find expected current-context string in kubeconfig.")
+		return ""
+	}
+	return strings.Split(config.CurrentContext, "/")[1]
 }


### PR DESCRIPTION
Includes small error check for current-context gathering.

Note: I would like to come back to this to use the dynamic go client to grab these resources but this is clean for now.