### PR TITLE
Add `apb config` cmd for configuring broker/catalog interaction vars

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -100,7 +100,7 @@ func listBrokerCatalog(brokerRouteName string, brokerNamespace string) {
 	if err != nil {
 		log.Errorf("Failed to get broker route: %v", err)
 		if strings.Contains(err.Error(), "cannot list routes") {
-			handleResourceInaccessibleErr("routes", brokerName, false)
+			handleResourceInaccessibleErr("routes", brokerRouteName, false)
 		}
 		return
 	}
@@ -156,7 +156,7 @@ func bootstrapBroker(brokerRouteName string, brokerNamespace string) {
 	if err != nil {
 		log.Errorf("Failed to get broker route: %v", err)
 		if strings.Contains(err.Error(), "cannot list routes") {
-			handleResourceInaccessibleErr("routes", brokerName, false)
+			handleResourceInaccessibleErr("routes", brokerRouteName, false)
 		}
 		return
 	}
@@ -190,7 +190,7 @@ func bootstrapBroker(brokerRouteName string, brokerNamespace string) {
 	if resp.StatusCode == 504 {
 		log.Errorf("Timed out waiting for broker bootstrap response.")
 		fmt.Print("Try increasing the route timeout with:\n")
-		fmt.Printf("oc annotate route asb -n %v --overwrite haproxy.router.openshift.io/timeout=60s\n", brokerName)
+		fmt.Printf("oc annotate route asb -n %v --overwrite haproxy.router.openshift.io/timeout=60s\n", brokerRouteName)
 		return
 	}
 
@@ -211,7 +211,7 @@ func bootstrapBroker(brokerRouteName string, brokerNamespace string) {
 		log.Errorf("Failed to unmarshal response: %v", err)
 	}
 
-	fmt.Printf("Successfully bootstrapped broker [%v]\n", brokerName)
+	fmt.Printf("Successfully bootstrapped broker [%v]\n", brokerRouteName)
 	fmt.Printf("Broker loaded %v valid APB specs from %v total images.\n", bootResp.SpecCount, bootResp.ImageCount)
 	return
 }

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -174,8 +174,8 @@ func init() {
 
 // ListImages finds and prints inforomation on bundle images from all the registries
 func ListImages() {
-	var regConfigs []Registry
-	var newRegConfigs []Registry
+	var regConfigs []config.Registry
+	var newRegConfigs []config.Registry
 
 	err := config.Registries.UnmarshalKey("Registries", &regConfigs)
 	if err != nil {
@@ -201,7 +201,7 @@ func ListImages() {
 	}
 	printRegConfigSpecs(newRegConfigs)
 
-	err = updateCachedRegistries(newRegConfigs)
+	err = config.UpdateCachedRegistries(newRegConfigs)
 	if err != nil {
 		log.Errorf("Error updating cache - %v", err)
 		return
@@ -221,7 +221,7 @@ func executeBundle(action string, args []string) {
 }
 
 // Get images from a single registry
-func getImages(registryMetadata Registry) ([]*bundle.Spec, error) {
+func getImages(registryMetadata config.Registry) ([]*bundle.Spec, error) {
 	var specList []*bundle.Spec
 
 	authNamespace := ""
@@ -244,7 +244,7 @@ func getImages(registryMetadata Registry) ([]*bundle.Spec, error) {
 	return specList, nil
 }
 
-func printRegConfigSpecs(regConfigs []Registry) {
+func printRegConfigSpecs(regConfigs []config.Registry) {
 	colFQName := &util.TableColumn{Header: "APB"}
 	colImage := &util.TableColumn{Header: "IMAGE"}
 	colRegName := &util.TableColumn{Header: "REGISTRY"}
@@ -284,7 +284,7 @@ func printBundleInfo(bundleSpec *bundle.Spec) {
 }
 
 func showBundleInfo(bundleName string, registryName string) {
-	var regConfigs []Registry
+	var regConfigs []config.Registry
 
 	err := config.Registries.UnmarshalKey("Registries", &regConfigs)
 	if err != nil {

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -25,12 +25,12 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/automationbroker/apb/pkg/config"
 	"github.com/automationbroker/apb/pkg/runner"
 	"github.com/automationbroker/apb/pkg/util"
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/registries"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -177,7 +177,7 @@ func ListImages() {
 	var regConfigs []Registry
 	var newRegConfigs []Registry
 
-	err := viper.UnmarshalKey("Registries", &regConfigs)
+	err := config.Registries.UnmarshalKey("Registries", &regConfigs)
 	if err != nil {
 		log.Error("Error unmarshalling config: ", err)
 		return
@@ -286,7 +286,7 @@ func printBundleInfo(bundleSpec *bundle.Spec) {
 func showBundleInfo(bundleName string, registryName string) {
 	var regConfigs []Registry
 
-	err := viper.UnmarshalKey("Registries", &regConfigs)
+	err := config.Registries.UnmarshalKey("Registries", &regConfigs)
 	if err != nil {
 		log.Error("Error unmarshalling config: ", err)
 		return

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -24,7 +24,7 @@ import (
 
 var completionCmd = &cobra.Command{
 	Use:   "completion",
-	Short: "Generates shell completion scripts.",
+	Short: "Generates shell completion scripts",
 	Long: `To load apb completion run
 
 source <(apb completion bash)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -28,7 +28,7 @@ var configCmd = &cobra.Command{
 	Short: "Set tool defaults",
 	Long:  `Runs an interactive prompt to configure defaults for the 'apb' tool.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gatherConfig()
+		gatherDefaultsConfig()
 	},
 }
 
@@ -36,13 +36,14 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 }
 
-func gatherConfig() {
+func gatherDefaultsConfig() {
 	defaultSettings := &config.DefaultSettings{
 		BrokerNamespace:          getUserInput("Broker namespace", config.InitialDefaultSettings().BrokerNamespace),
 		BrokerResourceURL:        getUserInput("Broker resource URL", config.InitialDefaultSettings().BrokerResourceURL),
 		BrokerRouteName:          getUserInput("Broker route name", config.InitialDefaultSettings().BrokerRouteName),
 		ClusterServiceBrokerName: getUserInput("clusterservicebroker", config.InitialDefaultSettings().ClusterServiceBrokerName),
 	}
+	fmt.Println("\nSaving new configuration....")
 	config.UpdateCachedDefaults(defaultSettings)
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/automationbroker/apb/pkg/config"
 	"github.com/spf13/cobra"
 )
 
@@ -36,10 +37,21 @@ func init() {
 }
 
 func gatherConfig() {
-	var brokerName string
-	fmt.Printf("Enter name of broker [default: openshift-automation-service-broker]: ")
-	fmt.Scanln(&brokerName)
-	if brokerName == "" {
-		brokerName = "openshift-automation-service-broker"
+	defaultSettings := &config.DefaultSettings{
+		BrokerNamespace:          getUserInput("Broker namespace", "openshift-automation-service-broker"),
+		BrokerResourceURL:        getUserInput("Broker resource URL", "/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/"),
+		BrokerRouteName:          getUserInput("Broker route name", "openshift-automation-service-broker"),
+		ClusterServiceBrokerName: getUserInput("clusterservicebroker name", "openshift-automation-service-broker"),
 	}
+	config.UpdateCachedDefaults(defaultSettings)
+}
+
+func getUserInput(prompt string, defaultValue string) string {
+	var userInput string
+	fmt.Printf("%s [default: %s]: ", prompt, defaultValue)
+	fmt.Scanln(&userInput)
+	if userInput == "" {
+		return defaultValue
+	}
+	return userInput
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,7 +41,7 @@ func gatherDefaultsConfig() {
 		BrokerNamespace:          getUserInput("Broker namespace", config.InitialDefaultSettings().BrokerNamespace),
 		BrokerResourceURL:        getUserInput("Broker resource URL", config.InitialDefaultSettings().BrokerResourceURL),
 		BrokerRouteName:          getUserInput("Broker route name", config.InitialDefaultSettings().BrokerRouteName),
-		ClusterServiceBrokerName: getUserInput("clusterservicebroker", config.InitialDefaultSettings().ClusterServiceBrokerName),
+		ClusterServiceBrokerName: getUserInput("clusterservicebroker resource name", config.InitialDefaultSettings().ClusterServiceBrokerName),
 	}
 	fmt.Println("\nSaving new configuration....")
 	config.UpdateCachedDefaults(defaultSettings)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,10 +38,10 @@ func init() {
 
 func gatherConfig() {
 	defaultSettings := &config.DefaultSettings{
-		BrokerNamespace:          getUserInput("Broker namespace", "openshift-automation-service-broker"),
-		BrokerResourceURL:        getUserInput("Broker resource URL", "/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/"),
-		BrokerRouteName:          getUserInput("Broker route name", "openshift-automation-service-broker"),
-		ClusterServiceBrokerName: getUserInput("clusterservicebroker name", "openshift-automation-service-broker"),
+		BrokerNamespace:          getUserInput("Broker namespace", config.InitialDefaultSettings().BrokerNamespace),
+		BrokerResourceURL:        getUserInput("Broker resource URL", config.InitialDefaultSettings().BrokerResourceURL),
+		BrokerRouteName:          getUserInput("Broker route name", config.InitialDefaultSettings().BrokerRouteName),
+		ClusterServiceBrokerName: getUserInput("clusterservicebroker", config.InitialDefaultSettings().ClusterServiceBrokerName),
 	}
 	config.UpdateCachedDefaults(defaultSettings)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Set tool defaults",
+	Long:  `Runs an interactive prompt to configure defaults for the 'apb' tool.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		gatherConfig()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}
+
+func gatherConfig() {
+	var brokerName string
+	fmt.Printf("Enter name of broker [default: openshift-automation-service-broker]: ")
+	fmt.Scanln(&brokerName)
+	if brokerName == "" {
+		brokerName = "openshift-automation-service-broker"
+	}
+}

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -21,16 +21,9 @@ import (
 
 	"github.com/automationbroker/apb/pkg/config"
 	"github.com/automationbroker/apb/pkg/util"
-	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/registries"
 	"github.com/spf13/cobra"
 )
-
-// Registry stores a single registry config and references all associated bundle specs
-type Registry struct {
-	Config registries.Config
-	Specs  []*bundle.Spec
-}
 
 // Default registry configuration section
 var defaultLocalOpenShiftConfig = registries.Config{
@@ -57,7 +50,7 @@ var defaultHelmConfig = registries.Config{
 }
 
 // Registry cmd vars
-var registryConfig Registry
+var registryConfig config.Registry
 
 // Registry commands
 var registryCmd = &cobra.Command{
@@ -109,15 +102,9 @@ func init() {
 	registryCmd.AddCommand(registryRemoveCmd)
 }
 
-func updateCachedRegistries(regList []Registry) error {
-	config.Registries.Set("Registries", regList)
-	config.Registries.WriteConfig()
-	return nil
-}
-
 func addRegistry(addName string) {
-	var regList []Registry
-	var newConfig Registry
+	var regList []config.Registry
+	var newConfig config.Registry
 	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Println("Error unmarshalling config: ", err)
@@ -148,12 +135,12 @@ func addRegistry(addName string) {
 		}
 	}
 	regList = append(regList, newConfig)
-	updateCachedRegistries(regList)
+	config.UpdateCachedRegistries(regList)
 	ListImages()
 	return
 }
 
-func printRegistries(regList []Registry) {
+func printRegistries(regList []config.Registry) {
 	colName := &util.TableColumn{Header: "NAME"}
 	colType := &util.TableColumn{Header: "TYPE"}
 	colOrg := &util.TableColumn{Header: "ORG"}
@@ -186,7 +173,7 @@ func applyOverrides(conf *registries.Config, params registries.Config) {
 }
 
 func listRegistries() {
-	var regList []Registry
+	var regList []config.Registry
 	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Printf("Error unmarshalling config: %v", err)
@@ -202,8 +189,8 @@ func listRegistries() {
 }
 
 func removeRegistry(name string) {
-	var regList []Registry
-	var newRegList []Registry
+	var regList []config.Registry
+	var newRegList []config.Registry
 	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Printf("Error unmarshalling config: %v", err)
@@ -212,7 +199,7 @@ func removeRegistry(name string) {
 		if r.Config.Name == name {
 			fmt.Printf("Found registry [%v]. Removing from list.\n", name)
 			newRegList = append(regList[:i], regList[i+1:]...)
-			updateCachedRegistries(newRegList)
+			config.UpdateCachedRegistries(newRegList)
 			return
 		}
 	}

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -19,11 +19,11 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/automationbroker/apb/pkg/config"
 	"github.com/automationbroker/apb/pkg/util"
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/registries"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // Registry stores a single registry config and references all associated bundle specs
@@ -110,15 +110,15 @@ func init() {
 }
 
 func updateCachedRegistries(regList []Registry) error {
-	viper.Set("Registries", regList)
-	viper.WriteConfig()
+	config.Registries.Set("Registries", regList)
+	config.Registries.WriteConfig()
 	return nil
 }
 
 func addRegistry(addName string) {
 	var regList []Registry
 	var newConfig Registry
-	err := viper.UnmarshalKey("Registries", &regList)
+	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Println("Error unmarshalling config: ", err)
 		return
@@ -187,7 +187,7 @@ func applyOverrides(conf *registries.Config, params registries.Config) {
 
 func listRegistries() {
 	var regList []Registry
-	err := viper.UnmarshalKey("Registries", &regList)
+	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Printf("Error unmarshalling config: %v", err)
 		return
@@ -204,7 +204,7 @@ func listRegistries() {
 func removeRegistry(name string) {
 	var regList []Registry
 	var newRegList []Registry
-	err := viper.UnmarshalKey("Registries", &regList)
+	err := config.Registries.UnmarshalKey("Registries", &regList)
 	if err != nil {
 		fmt.Printf("Error unmarshalling config: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,11 +51,14 @@ func init() {
 func initConfig() {
 	var isNewDefaultsConfig bool
 
+	// Load or create registries.json
 	config.Registries, _ = config.InitJSONConfig(cfgDir, "registries")
+	// Load or create defaults.json
 	config.Defaults, isNewDefaultsConfig = config.InitJSONConfig(cfgDir, "defaults")
 	if isNewDefaultsConfig {
 		config.UpdateCachedDefaults(config.InitialDefaultSettings())
 	}
+	config.LoadDefaultSettings()
 }
 
 // Execute invokes the root command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,17 +19,15 @@ package cmd
 import (
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/automationbroker/apb/pkg/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // Verbose controls the logging level, when enabled will set level to debug
 var Verbose bool
 
-// CfgFile is the configuration file
-var CfgFile string
+var cfgDir string
 
 var rootCmd = &cobra.Command{
 	Use:   "apb",
@@ -47,37 +45,12 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "configuration file (default is $HOME/.apb)")
+	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "configuration directory (default is $HOME/.apb)")
 }
 
 func initConfig() {
-	viper.SetConfigType("json")
-	if CfgFile != "" {
-		viper.SetConfigFile(CfgFile)
-	} else {
-		home, err := homedir.Dir()
-		if err != nil {
-			log.Error(err)
-			os.Exit(1)
-		}
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".apb")
-		filePath := home + "/.apb.json"
-		if err := viper.ReadInConfig(); err != nil {
-			log.Warning("Didn't find config file, creating one.")
-			file, err := os.Create(filePath)
-			if err != nil {
-				log.Error(err)
-				os.Exit(1)
-			}
-			file.WriteString("{}")
-		}
-	}
-
-	if err := viper.ReadInConfig(); err != nil {
-		log.Error("Can't read config: ", err)
-		os.Exit(1)
-	}
+	config.Defaults = config.InitJSONConfig(cfgDir, "defaults")
+	config.Registries = config.InitJSONConfig(cfgDir, "registries")
 }
 
 // Execute invokes the root command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,8 +49,13 @@ func init() {
 }
 
 func initConfig() {
-	config.Defaults = config.InitJSONConfig(cfgDir, "defaults")
-	config.Registries = config.InitJSONConfig(cfgDir, "registries")
+	var isNewDefaultsConfig bool
+
+	config.Registries, _ = config.InitJSONConfig(cfgDir, "registries")
+	config.Defaults, isNewDefaultsConfig = config.InitJSONConfig(cfgDir, "defaults")
+	if isNewDefaultsConfig {
+		config.UpdateCachedDefaults(config.InitialDefaultSettings())
+	}
 }
 
 // Execute invokes the root command

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ import (
 
 // Defaults stores command defaults
 var Defaults *viper.Viper
+var LoadedDefaults *DefaultSettings
 
 // Registries stores APB registry and spec data
 var Registries *viper.Viper
@@ -83,7 +84,7 @@ func UpdateCachedDefaults(defaults *DefaultSettings) error {
 	return nil
 }
 
-// InitialDefaultSettings provides sane default settings for interaction with the Automation Broker
+// InitialDefaultSettings provides a DefaultSettings struct with sane values for interaction with the Automation Broker
 func InitialDefaultSettings() *DefaultSettings {
 	return &DefaultSettings{
 		BrokerNamespace:          "openshift-automation-service-broker",
@@ -91,4 +92,9 @@ func InitialDefaultSettings() *DefaultSettings {
 		BrokerRouteName:          "openshift-automation-service-broker",
 		ClusterServiceBrokerName: "openshift-automation-service-broker",
 	}
+}
+
+// LoadDefaultSettings loads default settings from disk into a config.LoadedDefaults for later use
+func LoadDefaultSettings() {
+	Defaults.UnmarshalKey("Defaults", &LoadedDefaults)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ var Defaults *viper.Viper
 // Registries stores APB registry and spec data
 var Registries *viper.Viper
 
-// InitJSONConfig will load/create a JSON config at ~/configDir/configName
+// InitJSONConfig will load (or create if needed) a JSON config at ~/home/.apb/configName.json or configDir/configName.json
 func InitJSONConfig(configDir string, configName string) *viper.Viper {
 	var configPath string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	homedir "github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Defaults stores general tool defaults
+var Defaults *viper.Viper
+
+// Registries stores APB registry and spec data
+var Registries *viper.Viper
+
+// InitJSONConfig will load/create a JSON config at ~/configDir/configName
+func InitJSONConfig(configDir string, configName string) *viper.Viper {
+	var configPath string
+
+	viperConfig := viper.New()
+	viperConfig.SetConfigType("json")
+	if configDir != "" {
+		viperConfig.AddConfigPath(configDir)
+		configPath = configDir
+	} else {
+		home, err := homedir.Dir()
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+		configPath = filepath.Join(home, ".apb")
+	}
+	viperConfig.AddConfigPath(configPath)
+	viperConfig.SetConfigName(configName)
+	filePath := configPath + fmt.Sprintf("/%s.json", configName)
+	if err := viperConfig.ReadInConfig(); err != nil {
+		log.Warningf("Didn't find config file %s, creating.", filePath)
+		os.MkdirAll(configPath, 0755)
+		file, err := os.Create(filePath)
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+		file.WriteString("{}")
+	}
+	if err := viperConfig.ReadInConfig(); err != nil {
+		log.Error("Can't read config: ", err)
+		os.Exit(1)
+	}
+	return viperConfig
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,3 +67,17 @@ func InitJSONConfig(configDir string, configName string) *viper.Viper {
 	}
 	return viperConfig
 }
+
+// UpdateCachedRegistries saves the contents of regList to a configuration file
+func UpdateCachedRegistries(regList []Registry) error {
+	Registries.Set("Registries", regList)
+	Registries.WriteConfig()
+	return nil
+}
+
+// UpdateCachedDefaults saves the contents of deafults to a configuration file
+func UpdateCachedDefaults(defaults *DefaultSettings) error {
+	Defaults.Set("Defaults", defaults)
+	Defaults.WriteConfig()
+	return nil
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,8 +11,10 @@ type Registry struct {
 	Specs  []*bundle.Spec
 }
 
-// Default stores default settings for APB tool operation
-type Default struct {
-	Config registries.Config
-	Specs  []*bundle.Spec
+// DefaultSettings stores default settings for APB tool operation
+type DefaultSettings struct {
+	BrokerNamespace          string
+	BrokerResourceURL        string
+	BrokerRouteName          string
+	ClusterServiceBrokerName string
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,4 +1,4 @@
-package runner
+package config
 
 import (
 	"github.com/automationbroker/bundle-lib/bundle"
@@ -7,6 +7,12 @@ import (
 
 // Registry stores a single registry config and references all associated bundle specs
 type Registry struct {
+	Config registries.Config
+	Specs  []*bundle.Spec
+}
+
+// Default stores default settings for APB tool operation
+type Default struct {
 	Config registries.Config
 	Specs  []*bundle.Spec
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -26,12 +26,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/automationbroker/apb/pkg/config"
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/clients"
 	"github.com/automationbroker/bundle-lib/runtime"
 	"github.com/lestrrat/go-jsschema/validator"
 	"github.com/pborman/uuid"
-	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/api/core/v1"
 
@@ -45,7 +45,7 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
 	pn := fmt.Sprintf("bundle-%s", uuid.New())
-	viper.UnmarshalKey("Registries", &reg)
+	config.Registries.UnmarshalKey("Registries", &reg)
 	for _, r := range reg {
 		if len(bundleRegistry) > 0 && r.Config.Name != bundleRegistry {
 			continue

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -41,7 +41,7 @@ import (
 
 // RunBundle will run the bundle's action in the given namespace
 func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, skipParams bool, args []string) {
-	reg := []Registry{}
+	reg := []config.Registry{}
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
 	pn := fmt.Sprintf("bundle-%s", uuid.New())

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package util
 
 import (


### PR DESCRIPTION
`apb config` provides the ability to specify configuration variables for interaction with the Automation Broker. This should ease user issues when name changes occur. 

 - Add `apb config` command
 - Adapt `broker bootstrap/catalog` and `catalog relist` to use configuration values
 - Move config files (registries.json and new defaults.json) into ~/.apb dir


Example of keeping all defaults but changing name of clusterservicebroker
```
derek $ >> apb config
Broker namespace [default: openshift-automation-service-broker]: 
Broker resource URL [default: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/]: 
Broker route name [default: openshift-automation-service-broker]: 
clusterservicebroker [default: openshift-automation-service-broker]: ansible-service-broker

Saving new configuration....
derek $ >>
```