### PR TITLE
Add quay registry adapter

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -33,7 +33,7 @@ var defaultLocalOpenShiftConfig = registries.Config{
 	WhiteList:  []string{".*$"},
 }
 
-var defaultDockerHubConfig = registries.Config{
+var defaultQuayConfig = registries.Config{
 	Name:      "quay",
 	Type:      "quay",
 	URL:       "quay.io",

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -36,6 +36,7 @@ var defaultLocalOpenShiftConfig = registries.Config{
 var defaultQuayConfig = registries.Config{
 	Name:      "quay",
 	Type:      "quay",
+	Org:       "redhat",
 	URL:       "quay.io",
 	WhiteList: []string{".*$"},
 }

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -34,6 +34,13 @@ var defaultLocalOpenShiftConfig = registries.Config{
 }
 
 var defaultDockerHubConfig = registries.Config{
+	Name:      "quay",
+	Type:      "quay",
+	URL:       "quay.io",
+	WhiteList: []string{".*$"},
+}
+
+var defaultDockerHubConfig = registries.Config{
 	Name:      "dockerhub",
 	Type:      "dockerhub",
 	URL:       "docker.io",
@@ -119,6 +126,8 @@ func addRegistry(addName string) {
 		newConfig.Config = defaultLocalOpenShiftConfig
 	case "helm":
 		newConfig.Config = defaultHelmConfig
+	case "quay":
+		newConfig.Config = defaultQuayConfig
 	default:
 		fmt.Printf("Unrecognized registry type [%v]\n", registryConfig.Config.Type)
 		fmt.Printf("Supported types are: dockerhub, local_openshift, helm.\n")


### PR DESCRIPTION
Only thing I am unsure about is the default org... I am not aware of any quay registry orgs that have APBs.

I think it's fine to leave it blank and expect a user to input that.

Fixes #98 