### PR TITLE
Bug 1595153 - Add support for apb test that works in and out of cluster

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -238,7 +238,7 @@ func ListImages() {
 	}
 }
 
-func executeBundle(action string, args []string) string {
+func executeBundle(action string, args []string) (podName string) {
 	if bundleNamespace == "" {
 		bundleNamespace = util.GetCurrentNamespace(kubeConfig)
 		if bundleNamespace == "" {

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -258,9 +258,16 @@ func executeBundle(action string, args []string) (podName string) {
 // Check running pod if it has succeeded or not
 func checkTestSucceeded(podName string, namespace string) bool {
 	log.Infof("Monitoring test pod [%v] for status every 5 seconds...", podName)
-	status := runner.GetPodStatus(namespace, podName)
+	status, err := runner.GetPodStatus(namespace, podName)
+	if err != nil {
+		log.Errorf("Failed to get pod status for pod [%v]: %v", podName, err)
+		return false
+	}
 	for status != "Succeeded" && status != "Failed" {
-		status = runner.GetPodStatus(namespace, podName)
+		status, err = runner.GetPodStatus(namespace, podName)
+		if err != nil {
+			log.Errorf("Failed to get pod status for pod [%v]: %v", podName, err)
+		}
 		log.Infof("Test pod [%v] status: %v", podName, status)
 		time.Sleep(5 * time.Second)
 	}

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/automationbroker/apb/pkg/config"
 	"github.com/automationbroker/apb/pkg/runner"
@@ -104,6 +105,28 @@ var bundleDeprovisionCmd = &cobra.Command{
 	},
 }
 
+var bundleTestCmd = &cobra.Command{
+	Use:   "test <apb-name>",
+	Short: "test APB images",
+	Long:  `Test an APB from a registry adapter`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pn := executeBundle("test", args)
+		if pn == "" {
+			log.Errorf("Failed to execute bundle")
+			return
+		}
+		//using bundleNamespace here is safe because executeBundle ensures it's not empty
+		succeed := checkTestSucceeded(pn, bundleNamespace)
+		if succeed {
+			fmt.Printf("Test succeeded for bundle [%v]\n", args[0])
+			return
+		}
+		log.Errorf("Test failed for bundle [%v]. Check the logs for pod [%v] to see what went wrong.", args[0], pn)
+		return
+	},
+}
+
 var bundleInitStub = &cobra.Command{
 	Use:        "init <bundle-name>",
 	Deprecated: "use 'ansible-galaxy init --type=apb <bundle-name>'",
@@ -153,6 +176,13 @@ func init() {
 	bundleProvisionCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from provision pod")
 	rootCmd.AddCommand(createHiddenCmd(bundleProvisionCmd, ""))
 	bundleCmd.AddCommand(bundleProvisionCmd)
+
+	bundleTestCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision APB to")
+	bundleTestCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to APB sandbox")
+	bundleTestCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load APB from")
+	bundleTestCmd.Flags().BoolVarP(&printLogs, "follow", "f", false, "Print logs from provision pod")
+	rootCmd.AddCommand(createHiddenCmd(bundleTestCmd, "running `apb bundle test` instead."))
+	bundleCmd.AddCommand(bundleTestCmd)
 
 	bundleDeprovisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to deprovision APB from")
 	bundleDeprovisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to APB sandbox")
@@ -208,16 +238,37 @@ func ListImages() {
 	}
 }
 
-func executeBundle(action string, args []string) {
+func executeBundle(action string, args []string) string {
 	if bundleNamespace == "" {
 		bundleNamespace = util.GetCurrentNamespace(kubeConfig)
 		if bundleNamespace == "" {
 			log.Errorf("Failed to get current namespace. Try supplying it with --namespace.")
-			return
+			return ""
 		}
 	}
 	log.Debugf("Running bundle [%v] with action [%v] in namespace [%v].", args[0], action, bundleNamespace)
-	runner.RunBundle(action, bundleNamespace, args[0], sandboxRole, bundleRegistry, printLogs, skipParams, args[1:])
+	pn, err := runner.RunBundle(action, bundleNamespace, args[0], sandboxRole, bundleRegistry, printLogs, skipParams, args[1:])
+	if err != nil {
+		log.Errorf("Failed to execute bundle [%v]: %v", args[0], err)
+		return ""
+	}
+	return pn
+}
+
+// Check running pod if it has succeeded or not
+func checkTestSucceeded(podName string, namespace string) bool {
+	log.Infof("Monitoring test pod [%v] for status every 5 seconds...", podName)
+	status := runner.GetPodStatus(namespace, podName)
+	for status != "Succeeded" && status != "Failed" {
+		status = runner.GetPodStatus(namespace, podName)
+		log.Infof("Test pod [%v] status: %v", podName, status)
+		time.Sleep(5 * time.Second)
+	}
+	if status == "Succeeded" {
+		log.Debugf("Test pod [%v] succeeded", podName)
+		return true
+	}
+	return false
 }
 
 // Get images from a single registry

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -41,8 +41,6 @@ import (
 
 // RunBundle will run the bundle's action in the given namespace
 func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, skipParams bool, args []string) (podName string, err error) {
-	podName = ""
-	err = nil
 	reg := []config.Registry{}
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
@@ -165,18 +163,17 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	return
 }
 
-func GetPodStatus(namespace string, podName string) string {
+func GetPodStatus(namespace string, podName string) (string, error) {
 	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		panic(err.Error())
 	}
 	pod, err := k8scli.Client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Error getting pod [%v] status: %v", podName, err)
-		return ""
+		return "", err
 	}
 	status := pod.Status.Phase
-	return string(status)
+	return string(status), nil
 }
 
 func printBundleLogs(podName string, namespace string, action string) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -40,7 +40,7 @@ import (
 )
 
 // RunBundle will run the bundle's action in the given namespace
-func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, skipParams bool, args []string) {
+func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, skipParams bool, args []string) (string, error) {
 	reg := []config.Registry{}
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
@@ -60,15 +60,15 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	if len(candidateSpecs) == 0 {
 		if len(bundleRegistry) > 0 {
 			log.Errorf("Didn't find APB [%v] in registry [%v]\n", bundleName, bundleRegistry)
-			return
+			return "", errors.New(fmt.Sprintf("failed to find APB [%v] in registry [%v]", bundleName, bundleRegistry))
 		}
 		log.Errorf("Didn't find APB [%v] in configured registries\n", bundleName)
-		return
+		return "", errors.New(fmt.Sprintf("failed to find APB [%v] on configured registries", bundleName))
 		// TODO: return an ErrorBundleNotFound
 	}
 	if len(candidateSpecs) > 1 {
 		log.Warnf("Found multiple APBs matching name [%v]. Specify a registry with --registry.", bundleName)
-		return
+		return "", errors.New(fmt.Sprintf("found multiple APBs with matching name [%v]", bundleName))
 	}
 
 	targetSpec = candidateSpecs[0]
@@ -89,14 +89,14 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 		params, err = selectParameters(plan)
 		if err != nil {
 			log.Errorf("Error validating selected parameters: %v", err)
-			return
+			return "", err
 		}
 	}
 
 	extraVars, err := createExtraVars(ns, &params, plan)
 	if err != nil {
 		log.Errorf("Error creating extravars: %v\n", err)
-		return
+		return "", err
 	}
 
 	labels := map[string]string{
@@ -160,7 +160,7 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	if err != nil {
 		log.Errorf("Failed to create pod: %v", err)
 		// TODO: return ErrorPodCreationFailed
-		return
+		return "", err
 	}
 	fmt.Printf("Successfully created pod [%v] to %s [%v] in namespace [%v]\n", pn, ec.Action, bundleName, ns)
 
@@ -169,7 +169,21 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	}
 
 	// TODO: return nil
-	return
+	return pn, nil
+}
+
+func GetPodStatus(namespace string, podName string) string {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		panic(err.Error())
+	}
+	pod, err := k8scli.Client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Error getting pod [%v] status: %v", podName, err)
+		return ""
+	}
+	status := pod.Status.Phase
+	return string(status)
 }
 
 func printBundleLogs(podName string, namespace string, action string) {


### PR DESCRIPTION
In the past we were checking the contents of a file on the container to check if the APB succeeded in the test. This seemed incredibly pointless to me so instead I have talked with @djzager and determined we should simply judge a test status on whether or not the container is in a failed state or a succeeded state. This makes the workflow much simpler and now if a person wants to write a set of unit tests they can simply run the `fail` module in Ansible to signify a failed test which will put the pod in an error state.