### PR TITLE
Bug 1620042 - do not harcode in_cluster var & update docs

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -270,7 +270,7 @@ func getBrokerRoute(brokerRouteName string, brokerNamespace string) (string, err
 	}
 
 	for _, route := range rc.Items {
-		if route.Spec.To.Name == brokerRouteName {
+		if route.Name == brokerRouteName {
 			brokerRoute = fmt.Sprintf("https://%v/%v", route.Spec.Host, "osb")
 			return brokerRoute, nil
 		}

--- a/docs/apb_cli.md
+++ b/docs/apb_cli.md
@@ -262,7 +262,7 @@ Create binding out of secret `foo` and add it to Deployment Config `bar`
 apb binding add foo bar
 ```
 
-Our example APBs create secrets that match the name of the APB pod. So if you want to bind Postgresql APB to Mediawiki, you would first provision Postgresql (`apb bundle provision postgresql-apb`) and Mediawiki (`apb bundle provision mediawiki-apb`). Once they are done, you should see a secret named `bundle-<hash>` if you do `oc get secret`. Then find the name of the DeploymentConfig you want to bind to (`oc get dc`).If the DeploymentConfig is `mediawiki-1234` a binding command may look like
+Our example APBs create secrets that match the name of the APB pod. To bind Postgresql APB to Mediawiki, you would first provision Postgresql (`apb bundle provision postgresql-apb`) and Mediawiki (`apb bundle provision mediawiki-apb`). Once the APBs have finished provisioning, you should see a secret named `bundle-<hash>` when you run `oc get secret`. Then find the name of the DeploymentConfig you want to bind to (`oc get dc`).If the DeploymentConfig is `mediawiki-1234` a binding command may look like
 ```
 $ apb binding add bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40 mediawiki-1234
 INFO Create a binding using secret [bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40] to app [mediawiki-1234]                                                                                     

--- a/docs/apb_cli.md
+++ b/docs/apb_cli.md
@@ -262,6 +262,24 @@ Create binding out of secret `foo` and add it to Deployment Config `bar`
 apb binding add foo bar
 ```
 
+Our example APBs create secrets that match the name of the APB pod. So if you want to bind Postgresql APB to Mediawiki, you would first provision Postgresql (`apb bundle provision postgresql-apb`) and Mediawiki (`apb bundle provision mediawiki-apb`). Once they are done, you should see a secret named `bundle-<hash>` if you do `oc get secret`. Then find the name of the DeploymentConfig you want to bind to (`oc get dc`).If the DeploymentConfig is `mediawiki-1234` a binding command may look like
+```
+$ apb binding add bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40 mediawiki-1234
+INFO Create a binding using secret [bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40] to app [mediawiki-1234]                                                                                     
+
+Successfully created secret [bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40-creds] in namespace [apb].                                                                                          
+Use the following command to attach the binding to your application:
+oc set env dc/mediawiki-1234 --from=secret/bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40-creds
+```
+
+Type the recommended command:
+```
+$ oc set env dc/mediawiki-1234 --from=secret/bundle-772f6e70-3ee5-4fce-9c26-1dec57cc0c40-creds
+deploymentconfig "mediawiki-1234" updated
+```
+
+This will redeploy Mediawiki pod and you should see the full application backed by a Postgresql instance.
+
 ---
 ### `broker`
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -359,7 +359,6 @@ func createExtraVars(targetNamespace string, parameters *bundle.Parameters, plan
 	paramsCopy["_apb_plan_id"] = plan.Name
 	paramsCopy["_apb_service_instance_id"] = "1234"
 	paramsCopy["_apb_service_class_id"] = "1234"
-	paramsCopy["in_cluster"] = false
 	extraVars, err := json.Marshal(paramsCopy)
 	return string(extraVars), err
 }


### PR DESCRIPTION
The APBs will set their own defaults for in_cluster, there is no reason to hardcode them. We also really shouldn't be hardcoding the service_instance IDs. I will follow up with that.