### PR TITLE
Add broker route suffix as a config option

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -271,7 +271,7 @@ func getBrokerRoute(brokerRouteName string, brokerNamespace string) (string, err
 
 	for _, route := range rc.Items {
 		if route.Name == brokerRouteName {
-			brokerRoute = fmt.Sprintf("https://%v/%v", route.Spec.Host, "osb")
+			brokerRoute = fmt.Sprintf("https://%v/%v", route.Spec.Host, config.LoadedDefaults.BrokerRouteSuffix)
 			return brokerRoute, nil
 		}
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -42,6 +42,7 @@ func gatherDefaultsConfig() {
 		BrokerResourceURL:        getUserInput("Broker resource URL", config.InitialDefaultSettings().BrokerResourceURL),
 		BrokerRouteName:          getUserInput("Broker route name", config.InitialDefaultSettings().BrokerRouteName),
 		ClusterServiceBrokerName: getUserInput("clusterservicebroker resource name", config.InitialDefaultSettings().ClusterServiceBrokerName),
+		BrokerRouteSuffix:        getUserInput("Broker route suffix", config.InitialDefaultSettings().BrokerRouteSuffix),
 	}
 	fmt.Println("\nSaving new configuration....")
 	config.UpdateCachedDefaults(config.Defaults, defaultSettings)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ func InitialDefaultSettings() *DefaultSettings {
 		BrokerResourceURL:        "/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/",
 		BrokerRouteName:          "broker",
 		ClusterServiceBrokerName: "openshift-automation-service-broker",
+		BrokerRouteSuffix:        "osb",
 	}
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -17,4 +17,5 @@ type DefaultSettings struct {
 	BrokerResourceURL        string
 	BrokerRouteName          string
 	ClusterServiceBrokerName string
+	BrokerRouteSuffix        string
 }


### PR DESCRIPTION
Testing from a 3.9 cluster

```
[dymurray@pups apb]$ apb config                                         
Broker namespace [default: openshift-automation-service-broker]:        
Broker resource URL [default: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/]: ^C
[dymurray@pups apb]$ apb config                                         
Broker namespace [default: openshift-automation-service-broker]: ansible-service-broker
Broker resource URL [default: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/]:
Broker route name [default: broker]: asb                               
clusterservicebroker resource name [default: openshift-automation-service-broker]: ansible-service-broker
Broker route suffix [default: osb]:                                     
                                                                       
Saving new configuration....                                            
[dymurray@pups apb]$ apb broker catalog                                 
ERROR: logging before flag.Parse: I0822 17:27:09.475147   19499 client.go:206] handling failure responses
ERRO Failed fetch catalog: Status: 404; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>
[dymurray@pups apb]$ apb config                                        
Broker namespace [default: openshift-automation-service-broker]: ansible-service-broker
Broker resource URL [default: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/]:
Broker route name [default: broker]: asb
clusterservicebroker resource name [default: openshift-automation-service-broker]: ansible-service-broker
Broker route suffix [default: osb]: ansible-service-broker

Saving new configuration....
[dymurray@pups apb]$ apb broker catalog
 NAME                         ID                                   BINDABLE
 ------------------------ -+- -------------------------------- -+- --------
 dh-iscsi-demo-target-apb  |  595db86e75325f430afa4fa3f7d69af9  |  false
 dh-rhelvm-apb             |  411c51353e6605302235d3379de3ebd0  |  false
 dh-pyzip-demo-apb         |  0e991006d21029e47abe71acc255e807  |  false
```
