### PR TITLE
Bug 1625751 - Use uuids for service_instance labels

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,8 @@ func initConfig() {
 
 	// Load or create registries.json
 	config.Registries, _ = config.InitJSONConfig(cfgDir, "registries")
+	// Load or create instances.json
+	config.ProvisionedInstances, _ = config.InitJSONConfig(cfgDir, "instances")
 	// Load or create defaults.json
 	config.Defaults, isNewDefaultsConfig = config.InitJSONConfig(cfgDir, "defaults")
 	if isNewDefaultsConfig {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,21 +76,30 @@ func InitJSONConfig(configDir string, configName string) (config *viper.Viper, i
 // UpdateCachedInstances saves the contents of instanceList to a configuration file
 func UpdateCachedInstances(viperConfig *viper.Viper, instanceList []ProvisionedInstance) error {
 	viperConfig.Set("ProvisionedInstances", instanceList)
-	viperConfig.WriteConfig()
+	err := viperConfig.WriteConfig()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // UpdateCachedRegistries saves the contents of regList to a configuration file
 func UpdateCachedRegistries(viperConfig *viper.Viper, regList []Registry) error {
 	viperConfig.Set("Registries", regList)
-	viperConfig.WriteConfig()
+	err := viperConfig.WriteConfig()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // UpdateCachedDefaults saves the contents of defaults to a configuration file
 func UpdateCachedDefaults(viperConfig *viper.Viper, defaults *DefaultSettings) error {
 	viperConfig.Set("Defaults", defaults)
-	viperConfig.WriteConfig()
+	err := viperConfig.WriteConfig()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,9 @@ var LoadedDefaults DefaultSettings
 // Registries stores APB registry and spec data
 var Registries *viper.Viper
 
+// ProvisionedInstances stores APB instances
+var ProvisionedInstances *viper.Viper
+
 // InitJSONConfig will load (or create if needed) a JSON config at ~/home/.apb/configName.json or configDir/configName.json
 func InitJSONConfig(configDir string, configName string) (config *viper.Viper, isNewConfig bool) {
 	var configPath string
@@ -68,6 +71,13 @@ func InitJSONConfig(configDir string, configName string) (config *viper.Viper, i
 		os.Exit(1)
 	}
 	return viperConfig, isNewConfig
+}
+
+// UpdateCachedInstances saves the contents of instanceList to a configuration file
+func UpdateCachedInstances(viperConfig *viper.Viper, instanceList []ProvisionedInstance) error {
+	viperConfig.Set("ProvisionedInstances", instanceList)
+	viperConfig.WriteConfig()
+	return nil
 }
 
 // UpdateCachedRegistries saves the contents of regList to a configuration file

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -5,6 +5,12 @@ import (
 	"github.com/automationbroker/bundle-lib/registries"
 )
 
+// ProvisionedInstance stores a list of provisioned uuids associated with a bundle
+type ProvisionedInstance struct {
+	BundleName  string
+	InstanceIDs []string
+}
+
 // Registry stores a single registry config and references all associated bundle specs
 type Registry struct {
 	Config registries.Config

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,7 +8,7 @@ import (
 // ProvisionedInstance stores a list of provisioned uuids associated with a bundle
 type ProvisionedInstance struct {
 	BundleName  string
-	InstanceIDs []string
+	InstanceIDs map[string][]string
 }
 
 // Registry stores a single registry config and references all associated bundle specs

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -80,7 +80,6 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 	}
 
 	targetSpec = candidateSpecs[0]
-	log.Debugf("na: %v", targetSpec.FQName)
 
 	// determine the correct plan
 	plan := selectPlan(targetSpec)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -424,7 +424,7 @@ func getProvisionedInstanceId(name, namespace string) (string, error) {
 			if len(instance.InstanceIDs[namespace]) == 1 {
 				return instance.InstanceIDs[namespace][0], nil
 			} else if len(instance.InstanceIDs[namespace]) == 0 {
-				return "", fmt.Errorf("found no available instancesin namespace [%v]", namespace)
+				return "", fmt.Errorf("found no available instances in namespace [%v]", namespace)
 			} else {
 				// Select instance
 				fmt.Printf("Found more than one service instance for bundle [%v]:\n", name)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -42,9 +42,10 @@ import (
 // RunBundle will run the bundle's action in the given namespace
 func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, printLogs bool, skipParams bool, args []string) (podName string, err error) {
 	reg := []config.Registry{}
+	id := uuid.New()
 	var targetSpec *bundle.Spec
 	var candidateSpecs []*bundle.Spec
-	podName = fmt.Sprintf("bundle-%s", uuid.New())
+	podName = fmt.Sprintf("bundle-%s", id)
 	config.Registries.UnmarshalKey("Registries", &reg)
 	for _, r := range reg {
 		if len(bundleRegistry) > 0 && r.Config.Name != bundleRegistry {
@@ -88,7 +89,7 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 		}
 	}
 
-	extraVars, err := createExtraVars(ns, &params, plan)
+	extraVars, err := createExtraVars(id, ns, &params, plan)
 	if err != nil {
 		return "", err
 	}
@@ -343,7 +344,7 @@ func createPodEnv(executionContext runtime.ExecutionContext) []v1.EnvVar {
 	return podEnv
 }
 
-func createExtraVars(targetNamespace string, parameters *bundle.Parameters, plan bundle.Plan) (string, error) {
+func createExtraVars(id string, targetNamespace string, parameters *bundle.Parameters, plan bundle.Plan) (string, error) {
 	var paramsCopy bundle.Parameters
 	if parameters != nil && *parameters != nil {
 		paramsCopy = *parameters
@@ -357,8 +358,8 @@ func createExtraVars(targetNamespace string, parameters *bundle.Parameters, plan
 
 	paramsCopy["cluster"] = "openshift"
 	paramsCopy["_apb_plan_id"] = plan.Name
-	paramsCopy["_apb_service_instance_id"] = "1234"
-	paramsCopy["_apb_service_class_id"] = "1234"
+	paramsCopy["_apb_service_instance_id"] = id
+	paramsCopy["_apb_service_class_id"] = id
 	extraVars, err := json.Marshal(paramsCopy)
 	return string(extraVars), err
 }


### PR DESCRIPTION
Can now provision postgresql twice in the same namespace:

```
[dymurray@dymurray-desktop apb]$ oc get pods                          
NAME                                                      READY     STATUS      RESTARTS   AGE                                               
bundle-27df4f0b-9452-45ff-aad3-52b33e399118               0/1       Completed   0          23s                                               
bundle-fdf081f0-e609-4b70-883d-0c624b0800f9               0/1       Completed   0          3m                                                
postgresql-27df4f0b-9452-45ff-aad3-52b33e399118-1-n49xl   1/1       Running     0          11s                                               
postgresql-fdf081f0-e609-4b70-883d-0c624b0800f9-1-6zkls   1/1       Running     0          3m   
```