### PR TITLE
Bug 1626986 - Marshal ext creds instead of assuming interface type

### DIFF
--- a/cmd/binding.go
+++ b/cmd/binding.go
@@ -81,7 +81,12 @@ func addBinding(args []string) {
 	}
 	data := map[string][]byte{}
 	for key, value := range extCreds.Credentials {
-		data[key] = []byte(value.(string))
+		d, err := json.Marshal(value)
+		if err != nil {
+			log.Errorf("error marshalling extracted credential data: %v", err)
+			return
+		}
+		data[key] = d
 	}
 	s := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This fixes binding failures from `mysql-apb`. This is because MySQL is setting `DB_PORT` to `3306` instead of `"3306"` like we see with PostgreSQL.

Instead of forcing all this data to be a string we should be more defensive and simply marshal the data to get a byte array. This prevents unwanted panics.