### PR TITLE
Bug 1640050 - add `--kubeconfig` and `KUBECONFIG env` support

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -81,7 +81,6 @@ var bundleInfoCmd = &cobra.Command{
 
 var bundleNamespace string
 var sandboxRole string
-var kubeConfig string
 var printLogs bool
 var skipParams bool
 
@@ -153,9 +152,7 @@ var bundleBuildStub = &cobra.Command{
 }
 
 func init() {
-	bundleCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "Path to kubeconfig to use")
 	rootCmd.AddCommand(bundleCmd)
-
 	bundlePrepareCmd.Flags().StringVarP(&bundleMetadataFilename, "bundlemeta", "b", "apb.yml", "APB metadata file to encode as b64")
 	bundlePrepareCmd.Flags().StringVarP(&containerMetadataFilename, "containermeta", "c", "Dockerfile", "Container metadata file to stamp")
 	bundlePrepareCmd.Flags().BoolVarP(&noLineBreaks, "nolinebreak", "n", false, "Skip adding linebreaks to b64 APB spec")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/automationbroker/apb/pkg/config"
+	"github.com/automationbroker/apb/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,8 @@ import (
 var Verbose bool
 
 var cfgDir string
+
+var kubeConfig string
 
 var rootCmd = &cobra.Command{
 	Use:   "apb",
@@ -46,6 +49,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "configuration directory (default is $HOME/.apb)")
+	rootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "Path to kubeconfig to use (default is $HOME/.kube/config)")
 }
 
 func initConfig() {
@@ -59,6 +63,8 @@ func initConfig() {
 		config.UpdateCachedDefaults(config.Defaults, config.InitialDefaultSettings())
 	}
 	config.LoadDefaultSettings(config.Defaults, &config.LoadedDefaults)
+
+	kubeConfig = util.GetKubeConfigPath(kubeConfig)
 }
 
 // Execute invokes the root command

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -25,9 +26,6 @@ import (
 
 // GetCurrentNamespace returns the current OpenShift namespace or an empty string
 func GetCurrentNamespace(configPath string) string {
-	if configPath == "" {
-		configPath = clientcmd.RecommendedHomeFile
-	}
 	config, err := clientcmd.LoadFromFile(configPath)
 	if err != nil {
 		log.Errorf("Error loading kubeconfig from [%v]: %v", configPath, err)
@@ -38,4 +36,23 @@ func GetCurrentNamespace(configPath string) string {
 		return ""
 	}
 	return strings.Split(config.CurrentContext, "/")[0]
+}
+
+// GetKubeConfigPath returns a valid kubeconfig path
+func GetKubeConfigPath(kcPath string) string {
+	configPath := clientcmd.RecommendedHomeFile
+	kubeconfigEnv := os.Getenv("KUBECONFIG")
+
+	if len(kcPath) > 0 {
+		configPath = kcPath
+	} else if len(kubeconfigEnv) > 0 {
+		configPath = kubeconfigEnv
+	}
+
+	if _, err := os.Stat(configPath); err != nil {
+		log.Errorf("Error loading kubeconfig from [%v]: %v (Try setting the kubeconfig path with -k, --kubeconfig)", configPath, err)
+		os.Exit(1)
+	}
+
+	return configPath
 }


### PR DESCRIPTION
allow users to modify the default `$HOME/.kube/cofing` via the `--kubeconfig` or the `KUBECONFIG` environment variable