### PR TITLE
add cross compilation for Mac OS/X.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 apb
+apb-darwin-amd64
+apb-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 SOURCE_DIRS      = cmd pkg
 SOURCES          := $(shell find . -name '*.go' -not -path "*/vendor/*")
+PLATFORMS        = darwin linux
 .DEFAULT_GOAL    := apb
 
 apb: $(SOURCES) ## Build the samplebroker
 	go build -i -ldflags="-s -w"
+
+build-all:
+	$(foreach GOOS, $(PLATFORMS), $(shell export GOOS=$(GOOS); export GOARCH=amd64; go build -v -o apb-$(GOOS)-amd64 -i -ldflags="-s -w"))
 
 install:
 	go install -ldflags="-s -w"


### PR DESCRIPTION
Run `make build-all` and get both Linux and Mac OS/X executables. They will be named: `apb-darwin-amd64 and apb-linux-amd64`. 