### PR TITLE
set KUBECONFIG env for all commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func initConfig() {
 	config.LoadDefaultSettings(config.Defaults, &config.LoadedDefaults)
 
 	kubeConfig = util.GetKubeConfigPath(kubeConfig)
+	os.Setenv("KUBECONFIG", kubeConfig)
 }
 
 // Execute invokes the root command


### PR DESCRIPTION
[bz1640050](https://bugzilla.redhat.com/show_bug.cgi?id=1640050)

Depends on [bundle-lib PR](https://github.com/automationbroker/bundle-lib/pull/181)