### PR TITLE
make vet option correction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test: ## Run unit tests
 	@go test -cover ./cmd/... ./pkg/...
 
 vet: ## Run go vet
-	@go tool vet ./cmd ./pkg
+	@go vet ./cmd ./pkg
 
 check: fmtcheck vet lint apb test ## Pre-flight checks before creating PR
 


### PR DESCRIPTION
`make vet` fails because `go tool vet` is not supported.

```shell
$ make vet
vet: invoking "go tool vet" directly is unsupported; use "go vet"
Makefile:28: recipe for target 'vet' failed
make: *** [vet] Error 1
```

`go vet` is included in binary Go distributions.