### PR TITLE
Bug 1793365: fix permission for /etc/passwd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN yum -y install epel-release centos-release-openshift-origin \
 WORKDIR /mnt
 
 RUN echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/usermod
-RUN chmod 666 /etc/passwd
 
 ENTRYPOINT ["apb-wrapper"]
 CMD ["-h"]

--- a/apb-wrapper
+++ b/apb-wrapper
@@ -4,12 +4,21 @@ if [ -f /opt/apb/bin/activate ] ; then
  source /opt/apb/bin/activate
 fi
 
-if [ $UID == 0 ]; then
-  ln -sf /.kube /root/.kube
-else
-  echo "apb:x:$UID:$UID:apb:/home/apb:/bin/bash" >> /etc/passwd
-  sudo groupadd apb -g $UID
-  sudo usermod -a -G apb apb
+USER_ID=$(id -u)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+    NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cp /etc/passwd $NSS_WRAPPER_PASSWD
+
+    echo "${USER_NAME:-apb}:x:$(id -u):0:${USER_NAME:-apb} user:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+    export LD_PRELOAD
 fi
 
 if ! [[ "${MINISHIFT_REGISTRY}" == "" ]]; then

--- a/apb.spec
+++ b/apb.spec
@@ -70,6 +70,7 @@ Summary: %{summary}
 BuildArch: noarch
 
 Requires: golang
+Requires: nss_wrapper
 
 %description devel
 devel for %{name}


### PR DESCRIPTION
**Description**

Fis permission for etc/passwd

**Test**

```
 $ docker build -f Dockerfile .
Sending build context to Docker daemon  76.71MB
Step 1/8 : FROM centos:7
 ---> 5e35e350aded
Step 2/8 : RUN curl https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansible-service-broker-latest/repo/epel-7/group_ansible-service-broker-ansible-service-broker-latest-epel-7.repo -o /etc/yum.repos.d/asb.repo
 ---> Using cache
 ---> 6aa9389f43d7
Step 3/8 : RUN yum -y install epel-release centos-release-openshift-origin  && yum -y install apb-container-scripts sudo origin-clients  && yum clean all
 ---> Using cache
 ---> d556a78e1044
Step 4/8 : WORKDIR /mnt
 ---> Using cache
 ---> df479c974968
Step 5/8 : RUN echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/usermod
 ---> Using cache
 ---> 96c985a11614
Step 6/8 : ENTRYPOINT apb-wrapper
 ---> Using cache
 ---> 9eae24b7f7d2
Step 7/8 : CMD -h
 ---> Using cache
 ---> 04911151fe1d
Step 8/8 : LABEL RUN docker run --privileged -it --rm -v \${PWD}:/mnt -v \$HOME/.kube:/.kube -v \$HOME/.apb:/.apb -v /var/run/docker.sock:/var/run/docker.sock -u \${SUDO_UID} \${IMAGE}
 ---> Using cache
 ---> f361eaf447e8
Successfully built f361eaf447e8
$ docker run -it --entrypoint=/bin/bash  f361eaf447e8
[root@61408c000d06 mnt]#  ls -l /etc/passwd
-rw-r--r-- 1 root root 630 Oct  1 01:16 /etc/passwd
[root@61408c000d06 mnt]# exit
exit

```